### PR TITLE
Upgrade pyo3 to 0.22

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -37,12 +37,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
@@ -265,9 +259,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -290,15 +284,6 @@ name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "is-terminal"
@@ -390,16 +375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
-name = "lock_api"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,31 +427,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
 
 [[package]]
 name = "paste"
@@ -550,15 +500,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset 0.9.0",
- "parking_lot",
+ "once_cell",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -567,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -577,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -587,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -599,12 +550,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn 2.0.75",
 ]
@@ -636,15 +588,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -682,7 +625,7 @@ version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -781,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "termcolor"

--- a/native/libcst/Cargo.toml
+++ b/native/libcst/Cargo.toml
@@ -36,7 +36,7 @@ trace = ["peg/trace"]
 
 [dependencies]
 paste = "1.0.15"
-pyo3 = { version = "0.20", optional = true }
+pyo3 = { version = "0.22", optional = true }
 thiserror = "1.0.63"
 peg = "0.8.4"
 chic = "1.2.2"

--- a/native/libcst/src/nodes/expression.rs
+++ b/native/libcst/src/nodes/expression.rs
@@ -2524,6 +2524,7 @@ impl<'r, 'a> Inflate<'a> for DeflatedNamedExpr<'r, 'a> {
 #[cfg(feature = "py")]
 mod py {
 
+    use pyo3::types::PyAnyMethods;
     use pyo3::types::PyModule;
 
     use super::*;
@@ -2535,7 +2536,7 @@ mod py {
             match self {
                 Self::Starred(s) => s.try_into_py(py),
                 Self::Simple { value, comma } => {
-                    let libcst = PyModule::import(py, "libcst")?;
+                    let libcst = PyModule::import_bound(py, "libcst")?;
                     let kwargs = [
                         Some(("value", value.try_into_py(py)?)),
                         comma
@@ -2547,11 +2548,11 @@ mod py {
                     .filter(|x| x.is_some())
                     .map(|x| x.as_ref().unwrap())
                     .collect::<Vec<_>>()
-                    .into_py_dict(py);
+                    .into_py_dict_bound(py);
                     Ok(libcst
                         .getattr("Element")
                         .expect("no Element found in libcst")
-                        .call((), Some(kwargs))?
+                        .call((), Some(&kwargs))?
                         .into())
                 }
             }
@@ -2571,7 +2572,7 @@ mod py {
                     whitespace_before_colon,
                     ..
                 } => {
-                    let libcst = PyModule::import(py, "libcst")?;
+                    let libcst = PyModule::import_bound(py, "libcst")?;
                     let kwargs = [
                         Some(("key", key.try_into_py(py)?)),
                         Some(("value", value.try_into_py(py)?)),
@@ -2592,11 +2593,11 @@ mod py {
                     .filter(|x| x.is_some())
                     .map(|x| x.as_ref().unwrap())
                     .collect::<Vec<_>>()
-                    .into_py_dict(py);
+                    .into_py_dict_bound(py);
                     Ok(libcst
                         .getattr("DictElement")
                         .expect("no Element found in libcst")
-                        .call((), Some(kwargs))?
+                        .call((), Some(&kwargs))?
                         .into())
                 }
             }

--- a/native/libcst/src/nodes/parser_config.rs
+++ b/native/libcst/src/nodes/parser_config.rs
@@ -125,7 +125,7 @@ fn parser_config_asdict<'py>(py: Python<'py>, config: PyRef<'py, ParserConfig>) 
         ("version", config.version.clone_ref(py)),
         ("future_imports", config.future_imports.clone_ref(py)),
     ]
-    .into_py_dict(py)
+    .into_py_dict_bound(py)
 }
 
 pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {

--- a/native/libcst/src/nodes/traits.rs
+++ b/native/libcst/src/nodes/traits.rs
@@ -170,7 +170,7 @@ pub mod py {
                 .map(|x| x.try_into_py(py))
                 .collect::<PyResult<Vec<_>>>()?
                 .into_iter();
-            Ok(PyTuple::new(py, converted).into())
+            Ok(PyTuple::new_bound(py, converted).into())
         }
     }
 

--- a/native/libcst/src/parser/errors.rs
+++ b/native/libcst/src/parser/errors.rs
@@ -28,7 +28,7 @@ pub enum ParserError<'a> {
 #[cfg(feature = "py")]
 mod py_error {
 
-    use pyo3::types::{IntoPyDict, PyModule};
+    use pyo3::types::{IntoPyDict, PyAnyMethods, PyModule};
     use pyo3::{IntoPy, PyErr, PyErrArguments, Python};
 
     use super::ParserError;
@@ -65,13 +65,14 @@ mod py_error {
                     ("raw_line", (line + 1).into_py(py)),
                     ("raw_column", col.into_py(py)),
                 ]
-                .into_py_dict(py);
-                let libcst = PyModule::import(py, "libcst").expect("libcst cannot be imported");
-                PyErr::from_value(
+                .into_py_dict_bound(py);
+                let libcst =
+                    PyModule::import_bound(py, "libcst").expect("libcst cannot be imported");
+                PyErr::from_value_bound(
                     libcst
                         .getattr("ParserSyntaxError")
                         .expect("ParserSyntaxError not found")
-                        .call((), Some(kwargs))
+                        .call((), Some(&kwargs))
                         .expect("failed to instantiate"),
                 )
             })
@@ -86,7 +87,7 @@ mod py_error {
                 ("raw_line", self.raw_line.into_py(py)),
                 ("raw_column", self.raw_column.into_py(py)),
             ]
-            .into_py_dict(py)
+            .into_py_dict_bound(py)
             .into_py(py)
         }
     }

--- a/native/libcst/src/py.rs
+++ b/native/libcst/src/py.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 
 #[pymodule]
 #[pyo3(name = "native")]
-pub fn libcst_native(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn libcst_native(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     #[pyfn(m)]
     fn parse_module(source: String, encoding: Option<&str>) -> PyResult<PyObject> {
         let m = crate::parse_module(source.as_str(), encoding)?;

--- a/native/libcst/src/py.rs
+++ b/native/libcst/src/py.rs
@@ -10,6 +10,7 @@ use pyo3::prelude::*;
 #[pyo3(name = "native")]
 pub fn libcst_native(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     #[pyfn(m)]
+    #[pyo3(signature = (source, encoding=None))]
     fn parse_module(source: String, encoding: Option<&str>) -> PyResult<PyObject> {
         let m = crate::parse_module(source.as_str(), encoding)?;
         Python::with_gil(|py| m.try_into_py(py))


### PR DESCRIPTION
## Summary

This updates PyO3 to version 0.22, and adapt to the new APIs.

## Test Plan

```
cd native && cargo test
```